### PR TITLE
Provide update for several software elements in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,15 @@ RUN set -e \
  && apt-get install -y --no-install-recommends libjemalloc1 jq \
  && buildDeps="make gcc wget g++" \
  && apt-get install -y --no-install-recommends $buildDeps \
- && gem install -N fluentd -v "1.2.0" \
- && gem install -N fluent-plugin-systemd -v "0.3.1" \
- && gem install -N fluent-plugin-concat -v "2.2.2" \
- && gem install -N fluent-plugin-prometheus -v "1.0.1" \
+ && gem install -N fluentd -v "1.2.6" \
+ && gem install -N fluent-plugin-systemd -v "1.0.1" \
+ && gem install -N fluent-plugin-concat -v "2.3.0" \
+ && gem install -N fluent-plugin-prometheus -v "1.3.0" \
  && gem install -N fluent-plugin-jq -v "0.5.1" \
  && gem install -N fluent-plugin-splunk-hec -v "1.0.1" \
  && gem install -N oj -v "3.5.1" \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
- && wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_$dpkgArch \
+ && wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_$dpkgArch \
  && chmod +x /usr/bin/dumb-init \
  && apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \


### PR DESCRIPTION
Some of the Gem versions included in the `docker-fluentd-hec` are outdated, and relevant bugs have been addressed.

This change updates the included versions.